### PR TITLE
add tox.ini

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,13 @@ You can access the http://localhost:5000/xmlrpc at that point.
 Running the tests
 -----------------
 
-Install pytest, then run it for the ``tests/`` directory::
+You can invoke the tests with ``tox``::
+
+   $ pip install tox
+   $ tox
+
+Alternatively, you can run pytest directly. In this example I add the
+``--live`` argument to run against the live composedb instance::
 
    $ pip install pytest
-   $ python -m pytest tests/
+   $ python -m pytest --live tests/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+# Set RPM_PY_VERBOSE to "true" to debug koji package installation failures
+passenv = RPM_PY_VERBOSE
+deps =
+    pytest
+commands =
+    pytest -v


### PR DESCRIPTION
Update the docs to describe how to run `tox`.

Keep the direct pytest instructions and mention the special `--live` argument.