### PR TITLE
add RPM packaging and copr Makefile

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,48 @@
+# Copr does not have Git available. Install it before anything else.
+INSTALLER := $(shell [ -f /usr/bin/dnf ] && echo dnf || echo yum)
+INSTALL_GIT := $(shell [ -f /usr/bin/git ] || $(INSTALLER) -y install git)
+
+NAME = product-listings-manager
+VERSION := $(shell git describe --tags --abbrev=0 --match 'v*' | sed 's/^v//')
+COMMIT := $(shell git rev-parse HEAD)
+SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
+RELEASE := $(shell git describe --tags --match 'v*' \
+             | sed 's/^[^-]*-//' \
+             | sed 's/-/./')
+NVR := $(NAME)-$(VERSION)-$(RELEASE).el7
+
+# Copr will override this:
+outdir = .
+
+
+# Testing only
+echo:
+	echo COMMIT $(COMMIT)
+	echo VERSION $(VERSION)
+	echo RELEASE $(RELEASE)
+	echo NVR $(NVR)
+
+clean:
+	rm -rf dist/
+	rm -f $(NAME)-*.tar.gz
+	rm -f $(NAME)-*.src.rpm
+
+dist:
+	[ -f /usr/bin/python ] || $(INSTALLER) -y install python \
+	  && python setup.py sdist --dist-dir .
+
+spec:
+	sed $(NAME).spec.in \
+          -e 's/@COMMIT@/$(COMMIT)/' \
+          -e 's/@VERSION@/$(VERSION)/' \
+          -e 's/@RELEASE@/$(RELEASE)/' \
+          > $(NAME).spec
+
+srpm: spec dist
+	rpmbuild -bs $(NAME).spec \
+          --define "_topdir ." \
+          --define "_sourcedir ." \
+          --define "_srcrpmdir $(outdir)" \
+          --define "dist .el7"
+
+.PHONY: dist spec srpm

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 build/*
 dist/*
 doc/build/*
-instance/config.py
+/config.py

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/*
 dist/*
 doc/build/*
 /config.py
+/product-listings-manager.spec
+*.rpm

--- a/.travis/Dockerfile.centos:7
+++ b/.travis/Dockerfile.centos:7
@@ -20,7 +20,4 @@ RUN pip install tox
 
 COPY . .
 
-# live tests require this file :(
-COPY config.py instance/config.py
-
 CMD ["tox"]

--- a/.travis/Dockerfile.fedora:rawhide
+++ b/.travis/Dockerfile.fedora:rawhide
@@ -19,7 +19,4 @@ RUN yum -y --setopt skip_missing_names_on_install=False install \
 
 COPY . .
 
-# live tests require this file :(
-COPY config.py instance/config.py
-
 CMD ["tox"]

--- a/README.rst
+++ b/README.rst
@@ -73,17 +73,22 @@ Installation and setup
 
    $ python setup.py install
 
-5. Create ``instance/config.py`` with the database settings::
+5. Create ``config.py`` with the database settings::
 
-   $ cp config.py instance/config.py
-   $ vi instance/config.py
+   $ cp product_listings_manager/config.py config.py
+   $ vi config.py
 
-6. Install brewkoji package. This creates ``/etc/koji.conf.d/brewkoji.conf``,
+6. Set the ``FLASK_CONFIG`` environment variable to the full filesystem path of
+   this new file::
+
+   $ export FLASK_CONFIG=$(pwd)/config.py
+
+7. Install brewkoji package. This creates ``/etc/koji.conf.d/brewkoji.conf``,
    so ``products.py`` can contact the Brew hub::
 
    $ sudo yum -y install brewkoji
 
-7. Trust Brew's SSL certificate::
+8. Trust Brew's SSL certificate::
 
    $ export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
 
@@ -92,7 +97,7 @@ Installation and setup
 
    $ export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
-8. Run the server::
+9. Run the server::
 
    $ FLASK_APP=product_listings_manager.app flask run
 

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ product-listings-manager
 .. image:: https://travis-ci.org/ktdreyer/product-listings-manager.svg?branch=master
           :target: https://travis-ci.org/ktdreyer/product-listings-manager
 
+.. image:: https://copr.fedorainfracloud.org/coprs/ktdreyer/product-listings-manager/package/product-listings-manager/status_image/last_build.png
+          :target: https://copr.fedorainfracloud.org/coprs/ktdreyer/product-listings-manager/package/product-listings-manager/
+
 HTTP interface for finding product listings and interacting with data in
 composedb.
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,0 @@
-# composedb postgres settings
-dbname = "compose"
-dbhost = "db.example.com"
-dbuser = "myuser"
-dbpasswd = "mypassword"

--- a/product-listings-manager.spec.in
+++ b/product-listings-manager.spec.in
@@ -1,0 +1,91 @@
+%if 0%{?rhel} && 0%{?rhel} <= 7
+%bcond_with python3
+%else
+%bcond_without python3
+%endif
+
+%global modname product_listings_manager
+
+Name: product-listings-manager
+Version: @VERSION@
+Release: @RELEASE@%{?dist}
+Summary: HTTP interface to composedb
+
+License: MIT
+URL: https://github.com/ktdreyer/product-listings-manager
+Source0: %{name}-%{version}.tar.gz
+BuildArch: noarch
+
+%if %{with python3}
+BuildRequires: python3-devel
+BuildRequires: python3-flask
+BuildRequires: python3-flask-xml-rpc
+BuildRequires: python3-flask-restful
+BuildRequires: python3-koji
+BuildRequires: python3-pygresql
+BuildRequires: python3-pytest
+BuildRequires: python3-mock
+Requires: python3-flask
+Requires: python3-flask-xml-rpc
+Requires: python3-flask-restful
+Requires: python3-koji
+Requires: python3-pygresql
+%else
+BuildRequires: python2-devel
+BuildRequires: python-flask
+BuildRequires: python-flask-xml-rpc
+BuildRequires: python2-flask-restful
+BuildRequires: python2-koji
+BuildRequires: PyGreSQL
+BuildRequires: pytest
+BuildRequires: python-mock
+Requires: python-flask
+Requires: python-flask-xml-rpc
+Requires: python2-flask-restful
+Requires: python2-koji
+Requires: PyGreSQL
+%endif
+
+%description
+HTTP interface for finding product listings and interacting with data in
+composedb.
+
+%prep
+%autosetup
+
+
+%build
+%if %{with python3}
+%py3_build
+%else
+%py2_build
+%endif
+
+
+%install
+%if %{with python3}
+%py3_install
+%else
+%py2_install
+%endif
+
+%check
+export FLASK_CONFIG=config.py
+%if %{with python3}
+py.test-3 -v %{modname}/tests
+%else
+py.test-2.7 -v %{modname}/tests
+%endif
+
+%files
+%license LICENSE
+%doc README.rst
+%if %{with python3}
+%{python3_sitelib}/%{modname}/
+%{python3_sitelib}/%{modname}-*.egg-info/
+%else
+%{python2_sitelib}/%{modname}/
+%{python2_sitelib}/%{modname}-*.egg-info/
+%endif
+
+%changelog

--- a/product_listings_manager/app.py
+++ b/product_listings_manager/app.py
@@ -1,8 +1,18 @@
 from flask import Flask
 
 from product_listings_manager import rest_api_v1, xmlrpc
+from product_listings_manager import products
 
 app = Flask(__name__)
+
+# Set products.py's DB values from our Flask config:
+app.config.from_object('product_listings_manager.config')
+app.config.from_envvar('FLASK_CONFIG')
+products.dbname = app.config['DBNAME'] # eg. "compose"
+products.dbhost = app.config['DBHOST'] # eg "db.example.com"
+products.dbuser = app.config['DBUSER'] # eg. "myuser"
+products.dbpasswd = app.config['DBPASSWD'] # eg. "mypassword"
+
 app.register_blueprint(rest_api_v1.blueprint, url_prefix='/api/v1.0')
 xmlrpc.handler.connect(app, '/xmlrpc')
 

--- a/product_listings_manager/config.py
+++ b/product_listings_manager/config.py
@@ -1,0 +1,5 @@
+# composedb postgres settings
+DBNAME = "compose"
+DBHOST = "db.example.com"
+DBUSER = "myuser"
+DBPASSWD = "mypassword"

--- a/product_listings_manager/products.py
+++ b/product_listings_manager/products.py
@@ -4,7 +4,12 @@ import koji
 import pgdb
 import re
 import sys
-import instance.config
+
+dbname = None  # eg. "compose"
+dbhost = None  # eg "db.example.com"
+dbuser = None  # eg. "myuser"
+dbpasswd = None  # eg. "mypassword"
+
 
 class Products(object):
     """
@@ -178,10 +183,6 @@ class Products(object):
 
     def compose_get_dbh():
         # Database settings
-        dbname = instance.config.dbname
-        dbhost = instance.config.dbhost
-        dbuser = instance.config.dbuser
-        dbpasswd = instance.config.dbpasswd
         return pgdb.connect(database=dbname, host=dbhost, user=dbuser, password=dbpasswd)
     compose_get_dbh = staticmethod(compose_get_dbh)
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py27,py36
 [testenv]
 # Set RPM_PY_VERBOSE to "true" to debug koji package installation failures
 passenv = RPM_PY_VERBOSE
+setenv = FLASK_CONFIG = {toxinidir}/product_listings_manager/config.py
 deps =
     pytest
     mock


### PR DESCRIPTION
Copr can use this Makefile to build RPMs for each GitHub push at https://copr.fedorainfracloud.org/coprs/ktdreyer/product-listings-manager/

Note: RPM builds currently fail because we'll need to package `python-flask-xml-rpc-re`. I'm working on a `python-flask-xml-rpc-re.spec` file, and we can build that in the Copr, submit that to Fedora, build internally, etc.