### PR TITLE
switch to Flask-XML-RPC dependency

### DIFF
--- a/product_listings_manager/__init__.py
+++ b/product_listings_manager/__init__.py
@@ -1,6 +1,7 @@
 import traceback
 from flask import Flask
-from flask_xmlrpcre.xmlrepcre import XMLRPCHandler, Fault
+from flaskext.xmlrpc import XMLRPCHandler, Fault
+
 
 import product_listings_manager.products
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name="product-listings-manager",
       packages=find_packages(),
       install_requires=[
         'Flask',
-        'Flask-XML-RPC-Re',
+        'Flask-XML-RPC',
         'koji',
         'pygresql',
       ],


### PR DESCRIPTION
The Flask-XML-RPC-Re fork has Python 3 support, but it has a couple other problems.

1) test suite does not pass

2) latest code is not tagged

3) uncompiled source code is not distributed via PyPI

The Flask-XML-RPC module is essentially dead upstream, but it is packaged in [EPEL 7 and Fedora](https://apps.fedoraproject.org/packages/python-flask-xml-rpc). This module will get us far enough to the point that we can complete phase one for this project.

When we care about Python 3, we can drop XML-RPC entirely and get the service consumers to switch to a REST API instead.

(Note, with this change, the Travis CI tests will fail for Python 3. The solution is to drop XML-RPC support.)