### PR TITLE
MANIFEST.in: add LICENSE file to "sdist" tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Add the `LICENSE` file to the tarball we generate with `python setup.py sdist`.