### PR TITLE
fix Fault raising

### DIFF
--- a/product_listings_manager/xmlrpc.py
+++ b/product_listings_manager/xmlrpc.py
@@ -15,7 +15,7 @@ def getProductInfo(*a, **kw):
     except Exception as e:
         err = traceback.print_exc()
         current_app.logger.error(err)
-        raise Fault(e)
+        raise Fault(1, 'An unexpected error has occurred.')
 
 
 @handler.register
@@ -26,4 +26,4 @@ def getProductListings(*a, **kw):
         err = traceback.print_exc()
         # import pdb; pdb.set_trace()
         current_app.logger.error(err)
-        raise Fault(e)
+        raise Fault(1, 'An unexpected error has occurred.')


### PR DESCRIPTION
Flask-XML-RPC's `Fault` class is just `xmlrpclib.Fault`, and that takes two arguments: a fault code and a fault string. We were only passing the fault string, so we crashed in the `Fault` constructor here.

Prior to this change, something in `xmlrpclib` was casting the exception to some other data type. For example, if we caught `pg.InternalError`, `xmlrpclib` was translating that to a `dict` when sending that back through Flask to the client.

Print a generic string to the client so we don't accidentally leak information.