### PR TITLE
set products.py posgres connection from Flask config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 build/*
 dist/*
 doc/build/*
-instance/config.py
+/config.py

--- a/.travis/Dockerfile.centos:7
+++ b/.travis/Dockerfile.centos:7
@@ -20,7 +20,4 @@ RUN pip install tox
 
 COPY . .
 
-# live tests require this file :(
-COPY config.py instance/config.py
-
 CMD ["tox"]

--- a/.travis/Dockerfile.fedora:rawhide
+++ b/.travis/Dockerfile.fedora:rawhide
@@ -19,7 +19,4 @@ RUN yum -y --setopt skip_missing_names_on_install=False install \
 
 COPY . .
 
-# live tests require this file :(
-COPY config.py instance/config.py
-
 CMD ["tox"]

--- a/README.rst
+++ b/README.rst
@@ -73,17 +73,22 @@ Installation and setup
 
    $ python setup.py install
 
-5. Create ``instance/config.py`` with the database settings::
+5. Create ``config.py`` with the database settings::
 
-   $ cp config.py instance/config.py
-   $ vi instance/config.py
+   $ cp product_listings_manager/config.py config.py
+   $ vi config.py
 
-6. Install brewkoji package. This creates ``/etc/koji.conf.d/brewkoji.conf``,
+6. Set the ``FLASK_CONFIG`` environment variable to the full filesystem path of
+   this new file::
+
+   $ export FLASK_CONFIG=$(pwd)/config.py
+
+7. Install brewkoji package. This creates ``/etc/koji.conf.d/brewkoji.conf``,
    so ``products.py`` can contact the Brew hub::
 
    $ sudo yum -y install brewkoji
 
-7. Trust Brew's SSL certificate::
+8. Trust Brew's SSL certificate::
 
    $ export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
 
@@ -92,7 +97,7 @@ Installation and setup
 
    $ export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
-8. Run the server::
+9. Run the server::
 
    $ FLASK_APP=product_listings_manager.app flask run
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,0 @@
-# composedb postgres settings
-dbname = "compose"
-dbhost = "db.example.com"
-dbuser = "myuser"
-dbpasswd = "mypassword"

--- a/product_listings_manager/app.py
+++ b/product_listings_manager/app.py
@@ -1,8 +1,18 @@
 from flask import Flask
 
 from product_listings_manager import rest_api_v1, xmlrpc
+from product_listings_manager import products
 
 app = Flask(__name__)
+
+# Set products.py's DB values from our Flask config:
+app.config.from_object('product_listings_manager.config')
+app.config.from_envvar('FLASK_CONFIG')
+products.dbname = app.config['DBNAME'] # eg. "compose"
+products.dbhost = app.config['DBHOST'] # eg "db.example.com"
+products.dbuser = app.config['DBUSER'] # eg. "myuser"
+products.dbpasswd = app.config['DBPASSWD'] # eg. "mypassword"
+
 app.register_blueprint(rest_api_v1.blueprint, url_prefix='/api/v1.0')
 xmlrpc.handler.connect(app, '/xmlrpc')
 

--- a/product_listings_manager/config.py
+++ b/product_listings_manager/config.py
@@ -1,0 +1,5 @@
+# composedb postgres settings
+DBNAME = "compose"
+DBHOST = "db.example.com"
+DBUSER = "myuser"
+DBPASSWD = "mypassword"

--- a/product_listings_manager/products.py
+++ b/product_listings_manager/products.py
@@ -4,7 +4,12 @@ import koji
 import pgdb
 import re
 import sys
-import instance.config
+
+dbname = None  # eg. "compose"
+dbhost = None  # eg "db.example.com"
+dbuser = None  # eg. "myuser"
+dbpasswd = None  # eg. "mypassword"
+
 
 class Products(object):
     """
@@ -178,10 +183,6 @@ class Products(object):
 
     def compose_get_dbh():
         # Database settings
-        dbname = instance.config.dbname
-        dbhost = instance.config.dbhost
-        dbuser = instance.config.dbuser
-        dbpasswd = instance.config.dbpasswd
         return pgdb.connect(database=dbname, host=dbhost, user=dbuser, password=dbpasswd)
     compose_get_dbh = staticmethod(compose_get_dbh)
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py27,py36
 [testenv]
 # Set RPM_PY_VERBOSE to "true" to debug koji package installation failures
 passenv = RPM_PY_VERBOSE
+setenv = FLASK_CONFIG = {toxinidir}/product_listings_manager/config.py
 deps =
     pytest
     mock


### PR DESCRIPTION
Prior to this change, we were loading the Flask instance config module directly in products.py.

This makes it hard to run the test suite, because we had to copy `./config.py` to `./instance/config.py`.

This is complicated by the fact that setuptools does not store the sample config.py in the `python setup.py sdist` tarball, so it's even harder to run %check during the rpmbuild.

Move the default config into a `product_listings_manager.config` module.

Instruct the user to override the config settings with the new `FLASK_CONFIG` environment variable.

In the product_listings_manager application, after loading the products module, set the module's database variables from our Flask config's values.