### PR TITLE
tests: use yield_fixture for pytest 2.7 compatibility

### DIFF
--- a/product_listings_manager/tests/test_rest_api_v1.py
+++ b/product_listings_manager/tests/test_rest_api_v1.py
@@ -5,7 +5,7 @@ from mock import patch
 from product_listings_manager.app import app
 
 
-@pytest.fixture
+@pytest.yield_fixture
 def client():
     client = app.test_client()
     yield client


### PR DESCRIPTION
RHEL 7 has `pytest-2.7.0-1.el7`, and this needs the older `yield_fixture` decorator in order to `yield` from a fixture.

Pytest 2.10 and newer can use `yield` directly in normal fixtures.