### PR TITLE
tests: add get_json() for Flask 0.10 compat

### DIFF
--- a/product_listings_manager/tests/test_rest_api_v1.py
+++ b/product_listings_manager/tests/test_rest_api_v1.py
@@ -4,6 +4,15 @@ from mock import patch
 
 from product_listings_manager.app import app
 
+# Flask < 1.0 does not have get_json.
+from flask import Response
+import json
+if not hasattr(Response, 'get_json'):
+    def get_json(self, force=False, silent=False, cache=True):
+        """ Minimal implementation we can use this in the tests. """
+        return json.loads(self.data)
+    Response.get_json = get_json
+
 
 @pytest.fixture
 def client():


### PR DESCRIPTION
EPEL 7 has `python-flask-0.10.1-4.el7`, and `get_json()` is new in Flask 1.0.

Duck punch in a minimal implementation if `get_json()` is not already available in `flask.Response`.