### PR TITLE
README: update FLASK_APP name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Installation and setup
 
 8. Run the server::
 
-   $ FLASK_APP=product_listings_manager flask run
+   $ FLASK_APP=product_listings_manager.app flask run
 
 The Flask web server will run on TCP 5000.
 


### PR DESCRIPTION
With the move to `product_listings_manager/app.py` in e1da9358c1c0c49f6cf0ba9ab06c5660f9679097, we need to use a slightly different `FLASK_APP` value when running with `flask run`.