### PR TITLE
README: new pytest location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,4 +112,4 @@ Alternatively, you can run pytest directly. In this example I add the
 ``--live`` argument to run against the live composedb instance::
 
    $ pip install pytest
-   $ python -m pytest --live tests/
+   $ python -m pytest --live product_listings_manager/tests/


### PR DESCRIPTION
Describe how to run `pytest` directly, now that the tests have moved.