### PR TITLE
optionally load config from /etc or from FLASK_CONFIG

### DIFF
--- a/product_listings_manager/app.py
+++ b/product_listings_manager/app.py
@@ -7,7 +7,8 @@ app = Flask(__name__)
 
 # Set products.py's DB values from our Flask config:
 app.config.from_object('product_listings_manager.config')
-app.config.from_envvar('FLASK_CONFIG')
+app.config.from_pyfile('/etc/product-listings-manager/config.py', silent=True)
+app.config.from_envvar('FLASK_CONFIG', silent=True)
 products.dbname = app.config['DBNAME'] # eg. "compose"
 products.dbhost = app.config['DBHOST'] # eg "db.example.com"
 products.dbuser = app.config['DBUSER'] # eg. "myuser"


### PR DESCRIPTION
Apache's mod_wsgi has no easy way to pass the FLASK_CONFIG environment variable through to Python's os.environ.

Try loading the config settings from `FLASK_CONFIG` as well as `/etc/product-listings-manager/config.py`, treating both as optional.