### PR TITLE
products.py: pygresql 4 compatibility

### DIFF
--- a/product_listings_manager/products.py
+++ b/product_listings_manager/products.py
@@ -156,6 +156,9 @@ class Products(object):
 
         dbc = compose_dbh.cursor()
         qry = "SELECT DISTINCT trees.arch, packages.name FROM trees, packages, tree_packages WHERE trees.imported = 1 and trees.id = tree_packages.trees_id AND packages.id = tree_packages.packages_id AND packages.arch = %s AND packages.name = ANY(%s) AND trees.id = ANY(%s)"
+        if pgdb.version.startswith('4'):
+            # backwards compatibility with pygresql 4 in eng-rhel-7
+            qry = "SELECT DISTINCT trees.arch, packages.name FROM trees, packages, tree_packages WHERE trees.imported = 1 and trees.id = tree_packages.trees_id AND packages.id = tree_packages.packages_id AND packages.arch = %s AND packages.name IN %s AND trees.id IN %s"
         qargs = [src_arch, names, trees]
         if version:
             qry += " AND packages.version = %s"


### PR DESCRIPTION
42cd6ca29a9d8adec63bf7e3dfd8f2c3e8d97717 added pygresql 5 compatibility to this query.

Unfortunately eng-rhel-7 has PyGreSQL-4.0-9.el7 and this fails on this newer query.

Check the pygresql version and use the older query if necessary.