### PR TITLE
handle HTTP requests to "/" and "/api/v1.0/"

### DIFF
--- a/product_listings_manager/app.py
+++ b/product_listings_manager/app.py
@@ -1,6 +1,6 @@
 from flask import Flask
 
-from product_listings_manager import rest_api_v1, xmlrpc
+from product_listings_manager import root, rest_api_v1, xmlrpc
 from product_listings_manager import products
 
 app = Flask(__name__)
@@ -14,6 +14,7 @@ products.dbhost = app.config['DBHOST'] # eg "db.example.com"
 products.dbuser = app.config['DBUSER'] # eg. "myuser"
 products.dbpasswd = app.config['DBPASSWD'] # eg. "mypassword"
 
+app.register_blueprint(root.blueprint, url_prefix='/')
 app.register_blueprint(rest_api_v1.blueprint, url_prefix='/api/v1.0')
 xmlrpc.handler.connect(app, '/xmlrpc')
 

--- a/product_listings_manager/conftest.py
+++ b/product_listings_manager/conftest.py
@@ -1,3 +1,13 @@
+# Flask < 1.0 does not have get_json.
+from flask import Response
+import json
+if not hasattr(Response, 'get_json'):
+    def get_json(self, force=False, silent=False, cache=True):
+        """ Minimal implementation we can use this in the tests. """
+        return json.loads(self.data)
+    Response.get_json = get_json
+
+
 def pytest_addoption(parser):
     parser.addoption('--live', action='store_true',
                      help='query live composedb and koji servers')

--- a/product_listings_manager/rest_api_v1.py
+++ b/product_listings_manager/rest_api_v1.py
@@ -1,9 +1,24 @@
-from flask import Blueprint
+from flask import Blueprint, url_for
 from flask_restful import Resource, Api
 
 from product_listings_manager import __version__, products
 
 blueprint = Blueprint('api_v1', __name__)
+
+
+class Index(Resource):
+    def get(self):
+        """ Link to the the v1 API endpoints. """
+        return {
+            'about_url': url_for('.about', _external=True),
+            'product_info_url': url_for('.productinfo',
+                                        label=':label',
+                                        _external=True),
+            'product_listings_url': url_for('.productlistings',
+                                            label=':label',
+                                            build_info=':build_info',
+                                            _external=True),
+        }
 
 
 class About(Resource):
@@ -23,6 +38,7 @@ class ProductListings(Resource):
 
 
 api = Api(blueprint)
+api.add_resource(Index, '/')
 api.add_resource(About, '/about')
 api.add_resource(ProductInfo, '/product-info/<label>')
 api.add_resource(ProductListings, '/product-listings/<label>/<build_info>')

--- a/product_listings_manager/root.py
+++ b/product_listings_manager/root.py
@@ -1,0 +1,21 @@
+from flask import Blueprint, url_for
+from flask_restful import Resource, Api
+
+blueprint = Blueprint('/', __name__)
+
+
+DOCUMENTATION_URL = 'https://github.com/ktdreyer/product-listings-manager'
+
+
+class Index(Resource):
+    def get(self):
+        """ Link to the documentation and top-level API endpoints. """
+        return {
+            'documentation_url': DOCUMENTATION_URL,
+            'xmlrpc_url': url_for('xmlrpc', _external=True),
+            'api_v1_url': url_for('api_v1.index', _external=True),
+        }
+
+
+api = Api(blueprint)
+api.add_resource(Index, '/')

--- a/product_listings_manager/tests/test_rest_api_v1.py
+++ b/product_listings_manager/tests/test_rest_api_v1.py
@@ -11,6 +11,18 @@ def client():
     yield client
 
 
+class TestIndex(object):
+    def test_get_index(self, client):
+        r = client.get('/api/v1.0/')
+        expected_json = {
+            'about_url': 'http://localhost/api/v1.0/about',
+            'product_info_url': 'http://localhost/api/v1.0/product-info/:label',
+            'product_listings_url': 'http://localhost/api/v1.0/product-listings/:label/:build_info',
+        }
+        assert r.status_code == 200
+        assert r.get_json() == expected_json
+
+
 class TestAbout(object):
     def test_get_version(self, client):
         from product_listings_manager import __version__

--- a/product_listings_manager/tests/test_rest_api_v1.py
+++ b/product_listings_manager/tests/test_rest_api_v1.py
@@ -4,15 +4,6 @@ from mock import patch
 
 from product_listings_manager.app import app
 
-# Flask < 1.0 does not have get_json.
-from flask import Response
-import json
-if not hasattr(Response, 'get_json'):
-    def get_json(self, force=False, silent=False, cache=True):
-        """ Minimal implementation we can use this in the tests. """
-        return json.loads(self.data)
-    Response.get_json = get_json
-
 
 @pytest.yield_fixture
 def client():

--- a/product_listings_manager/tests/test_root.py
+++ b/product_listings_manager/tests/test_root.py
@@ -9,7 +9,7 @@ def client():
     yield client
 
 
-class TestAbout(object):
+class TestRoot(object):
     def test_get_version(self, client):
         r = client.get('/')
         expected_docs = 'https://github.com/ktdreyer/product-listings-manager'

--- a/product_listings_manager/tests/test_root.py
+++ b/product_listings_manager/tests/test_root.py
@@ -1,0 +1,22 @@
+import pytest
+
+from product_listings_manager.app import app
+
+
+@pytest.yield_fixture
+def client():
+    client = app.test_client()
+    yield client
+
+
+class TestAbout(object):
+    def test_get_version(self, client):
+        r = client.get('/')
+        expected_docs = 'https://github.com/ktdreyer/product-listings-manager'
+        expected_json = {
+            'api_v1_url': 'http://localhost/api/v1.0/',
+            'documentation_url': expected_docs,
+            'xmlrpc_url': 'http://localhost/xmlrpc',
+        }
+        assert r.status_code == 200
+        assert r.get_json() == expected_json


### PR DESCRIPTION
Return a small JSON response with links to the endpoints under `/` and `/api/v1.0/`.

The purpose of this change is to make the API more discoverable to clients    who are browsing around.