### PR TITLE
JSON responses for 404 errors

### DIFF
--- a/product_listings_manager/app.py
+++ b/product_listings_manager/app.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request, jsonify
 
 from product_listings_manager import rest_api_v1, xmlrpc
 from product_listings_manager import products
@@ -16,6 +16,13 @@ products.dbpasswd = app.config['DBPASSWD'] # eg. "mypassword"
 
 app.register_blueprint(rest_api_v1.blueprint, url_prefix='/api/v1.0')
 xmlrpc.handler.connect(app, '/xmlrpc')
+
+
+@app.errorhandler(404)
+def page_not_found_error(ex):
+    if not request.path.startswith('/xmlrpc'):
+        return jsonify({'error': str(ex)})
+
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
We return JSON for 200 and 500 responses. Return JSON for 404 errors as well, to make it easier for REST clients to handle the errors.