### PR TITLE
drop optional FLASK_CONFIG during tests and packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ RUN if [ "$cacert_url" != "undefined" ]; then \
 USER 1001
 EXPOSE 5000
 
-ENV FLASK_CONFIG "$config_path"
-
 ENTRYPOINT [ \
     "gunicorn", \
     "--bind=0.0.0.0:5000", \

--- a/product-listings-manager.spec.in
+++ b/product-listings-manager.spec.in
@@ -72,7 +72,6 @@ mkdir -p %{buildroot}%{_sysconfdir}/%{name}
 cp -p %{modname}/config.py %{buildroot}%{_sysconfdir}/%{name}
 
 %check
-export FLASK_CONFIG=config.py
 %if %{with python3}
 py.test-3 -v %{modname}/tests
 %else

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py27,py36
 [testenv]
 # Set RPM_PY_VERBOSE to "true" to debug koji package installation failures
 passenv = RPM_PY_VERBOSE
-setenv = FLASK_CONFIG = {toxinidir}/product_listings_manager/config.py
 deps =
     pytest
     mock


### PR DESCRIPTION
Commit aad6b826a3bd0850dc4242b7532c1cb2e593de93 made the `FLASK_CONFIG` environment variable optional. This means we no longer need to set it during the tests, packaging, or container.