### PR TITLE
Use uv sync in Dockerfile to pin dependencies to lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN set -exo pipefail \
         python3 \
     && dnf --installroot=/mnt/rootfs clean all \
     # Install uv
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && python3 -m venv /venv
+    && curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ENV \
     PIP_DEFAULT_TIMEOUT=100 \
@@ -50,12 +49,8 @@ ARG COMMIT_TIMESTAMP
 # hadolint ignore=SC1091
 RUN set -ex \
     && export PATH=/root/.cargo/bin:"$PATH" \
-    && . /venv/bin/activate \
     && uv version "1.1.2.dev$COMMIT_TIMESTAMP+git.$SHORT_COMMIT" \
-    && uv build --wheel \
-    && version=$(uv version --short) \
-    && pip install --no-cache-dir dist/product_listings_manager-"$version"-py3*.whl \
-    && deactivate \
+    && UV_PROJECT_ENVIRONMENT=/venv uv sync --frozen --no-dev --no-editable \
     && mv /venv /mnt/rootfs \
     && mkdir -p /mnt/rootfs/src/docker \
     && cp -v docker-entrypoint.sh /mnt/rootfs/src/docker \


### PR DESCRIPTION
Replace "uv build --wheel && pip install" with "uv sync --frozen --no-dev --no-editable" so the container installs exact versions from uv.lock instead of resolving from PyPI at build time.