### PR TITLE
Unbind LDAP connections to prevent file descriptor leaks

### DIFF
--- a/product_listings_manager/authorization.py
+++ b/product_listings_manager/authorization.py
@@ -29,6 +29,7 @@ def get_group_membership(
 
 
 def get_user_groups(user: str, ldap_config: LdapConfig) -> Generator[str, None, None]:
+    ldap_connection = None
     try:
         ldap_connection = ldap.initialize(ldap_config.host)
         if ldap_config.use_gssapi:
@@ -47,3 +48,6 @@ def get_user_groups(user: str, ldap_config: LdapConfig) -> Generator[str, None, 
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Unexpected LDAP connection error",
         )
+    finally:
+        if ldap_connection:
+            ldap_connection.unbind_s()


### PR DESCRIPTION
ldap.initialize() connections were never explicitly closed, relying on garbage collection to call ldap_unbind_ext. Add finally block to ensure unbind_s() is called even when exceptions occur.