### PR TITLE
Add yamllint, codespell, zizmor, and actionlint pre-commit hooks

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = docker/docker-entrypoint-initdb.d/05-init.sql

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -9,6 +9,9 @@ name: Gating
   workflow_dispatch:
     inputs: {}
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Unit tests
@@ -18,6 +21,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -59,6 +64,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,28 @@ repos:
     rev: v2.15.1
     hooks:
       - id: hadolint-docker
+
+  # YAML linter
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+
+  # Spell checker
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+
+  # GitHub Actions linters
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+      - id: zizmor
+        args:
+          - --min-severity=low
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    indent-sequences: whatever
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/product_listings_manager/models.py
+++ b/product_listings_manager/models.py
@@ -148,7 +148,7 @@ class Trees(BaseModel):
 class Overrides(BaseModel):
     """overrides table in composedb.
 
-    Many columns are set as primary key becasue primary key is required
+    Many columns are set as primary key because primary key is required
     in SQLAlchemy ORM and these columns are unique together.
 
     https://docs.sqlalchemy.org/en/latest/faq/ormconfiguration.html#how-do-i-map-a-table-that-has-no-primary-key


### PR DESCRIPTION
Add missing linter hooks and fix issues they found:
- yamllint with lenient indentation config
- codespell for spell checking (fo ignored as SQL alias)
- zizmor and actionlint for GitHub Actions workflows
- Fix typo found by codespell
- Add persist-credentials: false to checkout actions
- Add permissions block to GitHub Actions workflow

Assisted-by: Claude (Anthropic)